### PR TITLE
fixed decoding type

### DIFF
--- a/src/main/java/com/zooz/applepay/signatureverification/ApplePaySignatureVerifier.java
+++ b/src/main/java/com/zooz/applepay/signatureverification/ApplePaySignatureVerifier.java
@@ -171,7 +171,7 @@ public class ApplePaySignatureVerifier {
         byte[] transactionIdBytes = Hex.decode(applePayHeader.getTransactionId());
         byte[] applicationDataBytes = null;
         if (!StringUtils.isEmpty(applePayHeader.getApplicationData())) {
-            applicationDataBytes = Base64.decode(applePayHeader.getApplicationData());
+            applicationDataBytes = Hex.decode(applePayHeader.getApplicationData());
         }
 
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();


### PR DESCRIPTION
Optional applicationData is a Hex encoded SHA256 hash of the original input data (passed into the ApplePayPaymentRequest). The payment data retuned by Apple Pay should be Hex decoded rather than Base64 decoded.